### PR TITLE
Add preloader animations and interactive touches to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,46 +12,50 @@
       rel="stylesheet"
     />
   </head>
-  <body>
+  <body class="is-loading">
+    <div class="preloader" role="status" aria-live="polite">
+      <div class="preloader-spinner" aria-hidden="true"></div>
+      <span class="preloader-text">Preparing your dashboard…</span>
+    </div>
     <div class="app-shell">
       <aside class="sidebar">
         <div class="logo">JEDI</div>
         <nav class="menu">
           <a href="#" class="menu-item active">
             <span class="icon">🏠</span>
-            Home
+            <span class="label">Home</span>
           </a>
           <a href="#" class="menu-item">
             <span class="icon">📅</span>
-            Schedule
+            <span class="label">Schedule</span>
           </a>
           <a href="#" class="menu-item">
             <span class="icon">🧑‍🏫</span>
-            Trainers
+            <span class="label">Trainers</span>
           </a>
           <a href="#" class="menu-item">
             <span class="icon">📚</span>
-            Policy Library
+            <span class="label">Policy Library</span>
           </a>
           <a href="#" class="menu-item">
             <span class="icon">⚙️</span>
-            Preferences
+            <span class="label">Preferences</span>
           </a>
           <a href="#" class="menu-item">
             <span class="icon">🚪</span>
-            Log out
+            <span class="label">Log out</span>
           </a>
         </nav>
       </aside>
       <main class="content">
-        <div class="top-bar">
+        <div class="top-bar fade-in" style="--delay: 0.05s">
           <h1>Trainer info</h1>
           <div class="search">
             <input type="search" placeholder="Find courses, trainers, classes" />
           </div>
         </div>
         <section class="grid">
-          <article class="trainer-card">
+          <article class="trainer-card fade-in" style="--delay: 0.1s">
             <header class="trainer-header">
               <div class="avatar">
                 <img
@@ -83,12 +87,12 @@
               </div>
             </div>
             <div class="trainer-actions">
-              <button class="primary">Request session</button>
-              <button class="secondary">Portfolio</button>
+              <button class="primary" type="button">Request session</button>
+              <button class="secondary" type="button">Portfolio</button>
             </div>
           </article>
 
-          <article class="work-experience">
+          <article class="work-experience fade-in" style="--delay: 0.2s">
             <header>
               <h3>Work experience</h3>
             </header>
@@ -111,7 +115,7 @@
             </ul>
           </article>
 
-          <article class="student-reviews">
+          <article class="student-reviews fade-in" style="--delay: 0.3s">
             <header class="reviews-header">
               <h3>Students reviews</h3>
               <div class="rating">4.4 / 5.0</div>
@@ -136,26 +140,26 @@
             </div>
           </article>
 
-          <article class="students">
+          <article class="students fade-in" style="--delay: 0.4s">
             <header>
               <h3>Latest testimonials</h3>
             </header>
             <div class="student-cards">
-              <div class="student-card">
+              <div class="student-card" tabindex="0">
                 <div class="name">Nick H.</div>
                 <p>
                   "Hillary makes complex topics simple and engaging. I felt
                   supported throughout the course."
                 </p>
               </div>
-              <div class="student-card">
+              <div class="student-card" tabindex="0">
                 <div class="name">Stephanie W.</div>
                 <p>
                   "Her projects mirror real-life scenarios, which helped me land
                   a junior dev role."
                 </p>
               </div>
-              <div class="student-card">
+              <div class="student-card" tabindex="0">
                 <div class="name">Vane F.</div>
                 <p>
                   "Clear explanations, friendly mentorship, and high energy in
@@ -167,5 +171,97 @@
         </section>
       </main>
     </div>
+    <div class="prototype-toast" aria-live="polite"></div>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const preloader = document.querySelector(".preloader");
+        const appShell = document.querySelector(".app-shell");
+        const body = document.body;
+
+        const revealApp = () => {
+          if (preloader) {
+            preloader.classList.add("preloader--hidden");
+          }
+          if (appShell) {
+            appShell.classList.add("is-visible");
+          }
+          body.classList.remove("is-loading");
+          if (preloader) {
+            window.setTimeout(() => {
+              preloader.remove();
+            }, 600);
+          }
+        };
+
+        window.setTimeout(revealApp, 2000);
+
+        const menuItems = document.querySelectorAll(".menu-item");
+        const pageTitle = document.querySelector(".top-bar h1");
+
+        menuItems.forEach((item) => {
+          item.addEventListener("click", (event) => {
+            event.preventDefault();
+            menuItems.forEach((el) => el.classList.remove("active"));
+            item.classList.add("active");
+
+            const label = item.querySelector(".label");
+            if (label && pageTitle) {
+              pageTitle.textContent = label.textContent.trim();
+            }
+          });
+        });
+
+        const toast = document.querySelector(".prototype-toast");
+        const showToast = (message) => {
+          if (!toast) return;
+          toast.textContent = message;
+          toast.classList.add("prototype-toast--visible");
+          window.setTimeout(() => {
+            toast.classList.remove("prototype-toast--visible");
+          }, 1800);
+        };
+
+        const requestButton = document.querySelector("button.primary");
+        if (requestButton) {
+          requestButton.addEventListener("click", () => {
+            showToast("Session request sent!");
+          });
+        }
+
+        const portfolioButton = document.querySelector("button.secondary");
+        if (portfolioButton) {
+          portfolioButton.addEventListener("click", () => {
+            const newWindow = window.open(
+              "https://example.com/portfolio",
+              "_blank",
+              "noopener,noreferrer"
+            );
+            if (newWindow) {
+              newWindow.opener = null;
+            }
+          });
+        }
+
+        const studentCards = document.querySelectorAll(".student-card");
+        studentCards.forEach((card) => {
+          const activateCard = () => {
+            studentCards.forEach((item) => item.classList.remove("selected"));
+            card.classList.add("selected");
+            const name = card.querySelector(".name");
+            if (name) {
+              showToast(`${name.textContent.trim()} highlighted`);
+            }
+          };
+
+          card.addEventListener("click", activateCard);
+          card.addEventListener("keypress", (event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              activateCard();
+            }
+          });
+        });
+      });
+    </script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,52 @@ body {
   color: var(--text);
 }
 
+body.is-loading {
+  overflow: hidden;
+}
+
+.preloader {
+  position: fixed;
+  inset: 0;
+  background: rgba(245, 235, 218, 0.92);
+  backdrop-filter: blur(6px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  z-index: 20;
+  transition: opacity 0.5s ease, visibility 0.5s ease;
+}
+
+.preloader--hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.preloader-spinner {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 4px solid rgba(31, 43, 44, 0.15);
+  border-top-color: var(--accent);
+  animation: spin 1s linear infinite;
+}
+
+.preloader-text {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .app-shell {
   display: flex;
   width: min(1140px, 94vw);
@@ -40,6 +86,28 @@ body {
   border-radius: 28px;
   overflow: hidden;
   box-shadow: var(--shadow);
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+  pointer-events: none;
+}
+
+.app-shell.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 0.7s ease, transform 0.7s ease;
+  transition-delay: var(--delay, 0s);
+}
+
+.app-shell.is-visible .fade-in {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .sidebar {
@@ -74,6 +142,10 @@ body {
   font-weight: 600;
   color: var(--text);
   transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.menu-item .label {
+  white-space: nowrap;
 }
 
 .menu-item:hover,
@@ -354,6 +426,20 @@ button:hover {
   padding: 14px 16px;
   background: rgba(255, 255, 255, 0.85);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.student-card:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.student-card.selected {
+  border-color: var(--highlight-border);
+  background: #fffef5;
+  transform: translateY(-4px);
+  box-shadow: 0 14px 28px rgba(20, 30, 35, 0.12);
 }
 
 .student-card .name {
@@ -366,6 +452,28 @@ button:hover {
   font-size: 14px;
   color: #5d4d34;
   line-height: 1.4;
+}
+
+.prototype-toast {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  background: rgba(31, 43, 44, 0.85);
+  color: #fff;
+  padding: 12px 18px;
+  border-radius: 14px;
+  font-weight: 600;
+  box-shadow: 0 18px 30px rgba(15, 25, 25, 0.28);
+  opacity: 0;
+  transform: translateY(12px);
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 30;
+}
+
+.prototype-toast--visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 @media (max-width: 1000px) {


### PR DESCRIPTION
## Summary
- add a preloader overlay that reveals the dashboard after a two-second delay with smooth fade-ins
- enhance cards, sections, and navigation with staged fade-in animations and hover feedback
- wire up interactive prototype behaviors including navigation title changes, action toasts, and testimonial highlighting

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce2213bafc8324be82e875c517063a